### PR TITLE
Fix deprecated importlib.resources.paths in newer Python (e.g. 3.12.x)

### DIFF
--- a/pyprofqueue/profilers/prometheus.py
+++ b/pyprofqueue/profilers/prometheus.py
@@ -56,7 +56,7 @@ def define_initialise(profilefile: io.TextIOWrapper, profilerdict: dict = None):
         IP_address = profilerdict['ip_address']
         profilefile.write(f"export PROMETHEUS_IP={IP_address}\n")
     profilefile.write('export PROMETHEUS_RUNNING_DIR=${WORKING_DIR}/Prometheus\n')
-    scrape_path = str(impresources.path(data, 'read_prometheus.py'))[:-19]
+    scrape_path = str(impresources.files(data).joinpath("fake"))[:-5]
     profilefile.write('export PROFILE_SCRAPE={}\n'.format(scrape_path))
     profilefile.write('\n')
     final_init_indicator = 1


### PR DESCRIPTION
`importlib.resources.paths` has been deprecated in newer Pythons:

https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy

I don't like this fix much as it is clunky but ....

Very annoyingly, we are meant to use `files()` which returns a `MultiplexedPath` instance which is a frustratingly useless class, not least because calling `str()` on it returns `"MultiplexedPath('<path>')"` which is infuriatingly unhelpful. The only way it appears to get a string out of it is to `joinpath()` some fake value and substring it. I don't like this so if you can come up with a better fix please do.